### PR TITLE
 Replace data source lookup for "azurerm_resource_group" with variables to avoid resources recreation issue when re-applying the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ resource "azurerm_resource_group" "example" {
 
 module "network" {
   source              = "Azure/network/azurerm"
+  location            = "West Europe"
   resource_group_name = azurerm_resource_group.example.name
   address_spaces      = ["10.0.0.0/16", "10.2.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
@@ -48,6 +49,7 @@ resource "azurerm_resource_group" "example" {
 
 module "network" {
   source              = "Azure/network/azurerm"
+  location            = "West Europe"
   resource_group_name = azurerm_resource_group.example.name
   address_space       = "10.0.0.0/16"
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,8 @@
 #Azure Generic vNet Module
-data "azurerm_resource_group" "network" {
-  name = var.resource_group_name
-}
-
 resource "azurerm_virtual_network" "vnet" {
   name                = var.vnet_name
-  resource_group_name = data.azurerm_resource_group.network.name
-  location            = data.azurerm_resource_group.network.location
+  resource_group_name = var.resource_group_name
+  location            = var.location
   address_space       = length(var.address_spaces) == 0 ? [var.address_space] : var.address_spaces
   dns_servers         = var.dns_servers
   tags                = var.tags
@@ -15,7 +11,7 @@ resource "azurerm_virtual_network" "vnet" {
 resource "azurerm_subnet" "subnet" {
   count                                          = length(var.subnet_names)
   name                                           = var.subnet_names[count.index]
-  resource_group_name                            = data.azurerm_resource_group.network.name
+  resource_group_name                            = var.resource_group_name
   address_prefixes                               = [var.subnet_prefixes[count.index]]
   virtual_network_name                           = azurerm_virtual_network.vnet.name
   enforce_private_link_endpoint_network_policies = lookup(var.subnet_enforce_private_link_endpoint_network_policies, var.subnet_names[count.index], false)

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -14,6 +14,7 @@ resource "azurerm_resource_group" "test" {
 module "network" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.test.name
+  location            = var.location
   address_spaces      = ["10.0.0.0/16", "10.2.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,8 @@ variable "subnet_enforce_private_link_endpoint_network_policies" {
   type        = map(bool)
   default     = {}
 }
+
+variable "location" {
+  description = "The Azure Region where the resources should exist. Changing this forces a new Resource Group to be created"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,6 @@ variable "subnet_enforce_private_link_endpoint_network_policies" {
 }
 
 variable "location" {
-  description = "The Azure Region where the resources should exist. Changing this forces a new Resource Group to be created"
+  description = "The Azure Region where the resources should exist. Changing this forces a new resources to be created"
   type        = string
 }


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-network .
$ docker run --rm azure-network /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:


